### PR TITLE
Create /var/lib/influxdb as part of the influxdb postinst

### DIFF
--- a/builds/templates/deb/influxd/DEBIAN/postinst
+++ b/builds/templates/deb/influxd/DEBIAN/postinst
@@ -29,6 +29,9 @@ case "$1" in
 
     if [ -d /var/lib/influxdb ]; then
         chown influxdb:influxdb /var/lib/influxdb
+    else
+        mkdir -p /var/lib/influxdb
+        chown influxdb:influxdb /var/lib/influxdb
     fi
 
     if [ -d /var/log/influxdb ]; then


### PR DESCRIPTION
The package runs influxd as a systemd service as the `influxdb` user with a home directory of `/var/lib/influxdb`

Influxd will try to create a directory for itself in `$HOME/.influxdbv2`

Because the postinst script doesn't create `/var/lib/influxdb`, and because the `influxdb` user doesn't have permission to create a directory under `/var/lib`, the systemd service fails to start the InfluxDB server.

This patch will have the package installation process create `/var/lib/influxdb` and grant `influxdb` user ownership of it at install time.