### PR TITLE
Separate and isolate build targets

### DIFF
--- a/build_all.sh
+++ b/build_all.sh
@@ -1,13 +1,14 @@
 #!/bin/bash
 # Declare an array of string with type
 #("ubuntu" "i386/ubuntu:eoan-20200410" "arm32v7/ubuntu:eoan-20200410" "centos" "arm64v8/ubuntu:eoan-20200608")
-declare -a TargetsArray=("ubuntu")
+declare -a TargetsArray=("ubuntu" "centos" "i386/ubuntu:eoan-20200410" "arm64v8/ubuntu:eoan-20200608" "arm32v7/ubuntu:eoan-20200410")
 echo "Checking Docker installation"
 if ! [ -x "$(command -v docker)" ]; then
   echo 'Error: docker is not installed. Install docker first. try "sudo apt install docker.io" or equivalent' >&2
   exit 1
 else
   echo 'We have docker installed'
+  
 fi
 #Iterate through TargetsArray
 for val in ${TargetsArray[@]}; do
@@ -19,8 +20,9 @@ for val in ${TargetsArray[@]}; do
            docker rm $val
        fi
        cp influx_builder.sh ${PWD}/builds
+       target_logfile=$(echo $val | sed -e "s/[\\/\\:]/-/g").log
 # docker run -it --rm -v ${PWD}/builds:/mnt/builds $val /bin/bash
-docker run -i --rm -v ${PWD}/builds:/mnt/builds $val /bin/bash << COMMANDS
+docker run -i --rm -v ${PWD}/builds:/mnt/builds $val /bin/bash << COMMANDS 2>&1 |tee ${PWD}/builds/${target_logfile}
 rm -rf /mnt/builds/influxdb
 cd /mnt/builds/
 ./influx_builder.sh

--- a/influx_builder.sh
+++ b/influx_builder.sh
@@ -162,9 +162,15 @@ function make_project(){
   export GO111MODULE=on
   cd influxdb
   find . -name 'node_modules' -type d -prune -print -exec rm -rf '{}' \;
-  make && cd ..
+  make
+  if [ "$?" != "0" ]; then
+      echo "Build failed for ${DISTRO}_${arch}"
+      exit 1
+  fi
+  cd ..
 }
 function copy_files(){
+  echo "Creating packaging directory for ${DISTRO}_${arch}"
   sudo rm -rf ${DISTRO}_${arch}
   mkdir ${DISTRO}_${arch}
   cp -avr influxdb/bin/linux/. ${DISTRO}_${arch}
@@ -182,8 +188,8 @@ function packager(){
 function package_deb(){
   cp -avr ${PWD}/templates/deb/ ${DISTRO}_${arch}/packages
 
-  mkdir ${DISTRO}_${arch}/packages/influxd/usr/bin
-  mkdir ${DISTRO}_${arch}/packages/influx/usr/bin
+  mkdir -p ${DISTRO}_${arch}/packages/influxd/usr/bin
+  mkdir -p ${DISTRO}_${arch}/packages/influx/usr/bin
   cp ${DISTRO}_${arch}/influxd ${DISTRO}_${arch}/packages/influxd/usr/bin/influxd
   cp ${DISTRO}_${arch}/influx ${DISTRO}_${arch}/packages/influx/usr/bin/influx
   sudo chmod -R 755 ${DISTRO}_${arch}


### PR DESCRIPTION
* Produce separate build logs for each target.
* Abort a package build if the make step fails