### PR TITLE
Add snap build target

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Declare an array of string with type
-declare -a DefaultTargets=("ubuntu" "debian" "centos" "fedora")
+declare -a DefaultTargets=("ubuntu" "debian" "centos" "fedora" "snapcore/snapcraft")
 declare -a x86Targets=("i386/ubuntu:eoan-20200410")
 declare -a arm32Targets=("arm32v7/ubuntu:eoan-20200410")
 declare -a arm64Targets=("arm64v8/ubuntu:eoan-20200608")

--- a/builds/templates/snap/influx/snapcraft.yaml
+++ b/builds/templates/snap/influx/snapcraft.yaml
@@ -1,0 +1,37 @@
+name: influx
+base: core18
+version: __VERSION__
+summary: InfluxDB Client
+description: |
+  Commandline client for interacting with InfluxDB
+
+grade: devel
+confinement: strict
+
+architectures:
+  - build-on: amd64
+  - build-on: i386
+  - build-on: arm64
+plugs:
+  config-influxdb:
+    interface: personal-files
+    read:
+    - $HOME/.influxdbv2
+    write:
+    - $HOME/.influxdbv2
+
+parts:
+  influx:
+    plugin: dump
+    source: bin/
+
+
+apps:
+  influx:
+    command: influx
+    plugs:
+      - home
+      - removable-media
+      - network
+      - config-influxdb
+

--- a/builds/templates/snap/influxd/snapcraft.yaml
+++ b/builds/templates/snap/influxd/snapcraft.yaml
@@ -1,0 +1,29 @@
+name: influxdb
+base: core18
+version: __VERSION__
+summary: InfluxDB
+description: |
+  Scalable datastore for metrics, events, and real-time analytics.
+
+grade: stable
+confinement: strict
+
+architectures:
+  - build-on: amd64
+  - build-on: i386
+  - build-on: arm64
+
+parts:
+  influxdb:
+    plugin: dump
+    source: bin/
+
+apps:
+
+  influxd:
+    command: influxd --bolt-path $SNAP_COMMON/influxd.bolt --engine-path $SNAP_COMMON/engine
+    daemon: simple
+    plugs:
+      - network
+      - network-bind
+


### PR DESCRIPTION
Uses the `snapcore/snapcraft` Docker image and `./builds/templates/snap/` files to build client and server snaps 